### PR TITLE
Move regex capture groups to constant variables.

### DIFF
--- a/filetags.py
+++ b/filetags.py
@@ -80,6 +80,8 @@ FILE_WITH_TAGS_REGEX_TAGLIST_INDEX = 2
 FILE_WITH_TAGS_REGEX_EXTENSION_INDEX = 4
 
 FILE_WITH_EXTENSION_REGEX = re.compile("(.*)\.(.*)$")
+FILE_WITH_EXTENSION_REGEX_FILENAME_INDEX = 1
+FILE_WITH_EXTENSION_REGEX_EXTENSION_INDEX = 2
 
 
 parser = OptionParser(usage=USAGE)
@@ -242,8 +244,8 @@ def adding_tag_to_filename(filename, tagname):
 
         components = re.match(FILE_WITH_EXTENSION_REGEX, os.path.basename(filename))
         if components:
-            old_filename = components.group(1)
-            extension = components.group(2)
+            old_filename = components.group(FILE_WITH_EXTENSION_REGEX_FILENAME_INDEX)
+            extension = components.group(FILE_WITH_EXTENSION_REGEX_EXTENSION_INDEX)
             return os.path.join(os.path.dirname(filename), old_filename + FILENAME_TAG_SEPARATOR + tagname + u'.' + extension)
         else:
             return os.path.join(os.path.dirname(filename), os.path.basename(filename) + FILENAME_TAG_SEPARATOR + tagname)
@@ -259,8 +261,8 @@ def adding_tag_to_filename(filename, tagname):
 
         components = re.match(FILE_WITH_EXTENSION_REGEX, os.path.basename(filename))
         if components:
-            old_filename = components.group(1)
-            extension = components.group(2)
+            old_filename = components.group(FILE_WITH_EXTENSION_REGEX_FILENAME_INDEX)
+            extension = components.group(FILE_WITH_EXTENSION_REGEX_EXTENSION_INDEX)
             return os.path.join(os.path.dirname(filename), old_filename + BETWEEN_TAG_SEPARATOR + tagname + u'.' + extension)
         else:
             return os.path.join(os.path.dirname(filename), filename + BETWEEN_TAG_SEPARATOR + tagname)


### PR DESCRIPTION
Moves regex capture groups for "FILE_WITH_EXTENSION_REGEX" to constant
variables as to match the convention used for "FILE_WITH_TAGS_REGEX".