### PR TITLE
replace an outdated requirement by a new one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyreadline
+pyreadline3
 colorama
 clint


### PR DESCRIPTION
The installation of the previous version in Windows 10 and Python 3.10.X did not yield a functional application.  According to a discussion on python-forum.de[1], the likely cause to not offer an input mask for a user-defined tag was the outdated requirement pyreadline now substituted by pyreadline3.

[1] https://www.python-forum.de/viewtopic.php?p=411134#p411134