### PR TITLE
Added check to avoid stty error when stdin is redirected

### DIFF
--- a/filetags/__init__.py
+++ b/filetags/__init__.py
@@ -81,10 +81,14 @@ if platform.system() == 'Windows':
     TTY_HEIGHT, TTY_WIDTH = 80, 80  # fall-back values
     IS_WINDOWS = True
 else:
-    try:
-        TTY_HEIGHT, TTY_WIDTH = [int(x) for x in os.popen('stty size', 'r').read().split()]
-    except ValueError:
-        TTY_HEIGHT, TTY_WIDTH = 80, 80  # fall-back values
+    # check to avoid unrecoverable stty error when stdin is not a terminal.
+    if sys.stdin.isatty():
+        try:
+            TTY_HEIGHT, TTY_WIDTH = [int(x) for x in os.popen('stty size', 'r').read().split()]
+        except ValueError:
+            TTY_HEIGHT, TTY_WIDTH = 80, 80  # fall-back values
+    else:
+        TTY_HEIGHT, TTY_WIDTH = 80, 80
 
 max_file_length = 0  # will be set after iterating over source files182
 

--- a/filetags/__init__.py
+++ b/filetags/__init__.py
@@ -81,7 +81,7 @@ if platform.system() == 'Windows':
     TTY_HEIGHT, TTY_WIDTH = 80, 80  # fall-back values
     IS_WINDOWS = True
 else:
-    # check to avoid unrecoverable stty error when stdin is not a terminal.
+    # check to avoid stty error when stdin is not a terminal.
     if sys.stdin.isatty():
         try:
             TTY_HEIGHT, TTY_WIDTH = [int(x) for x in os.popen('stty size', 'r').read().split()]


### PR DESCRIPTION
After attempting to write a Tcl/Tk frontend for use with Geeqie, I found some odd behavior related to the stdin being redirected.

If stdin is redirected, the call to stty will fail, printing the message "stty: 'standard input': Inappropriate ioctl for device" to stderr.

This message can be recreated with

> echo | stty

or

> echo | filetags -t tag1 file1

This does not halt filetags, it will continue with the fallback values for the tty. But if it is called from another program that relies on stderr to determine success, it can cause unexpected behavior.

This was revealed upon wrapping it in a Tcl/Tk script and executing with the "wish" interpreter.

Wish, upon applying exec to an external program, watches stderr for any messages from it, pausing execution and displaying an error window for any message it receives.

If Geeqie has a plugin calling this wrapper, it redirects stdin to the plugin calls, causing the error to appear.

This can be recreated in the following steps where test.tcl contains "exec filetags -t tag1 file1" and filetags exists in your $PATH.

> echo | wish test.tcl

I believe this will resolve #12, however I can not confirm as I do not have access to any Mac device.