### PR TITLE
relax constraint on Python interpreter

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,11 +85,13 @@ If you have installed Python 2 and Python 3 in parallel, make sure to
 use the correct pip version. You might need to use =pip3= instead of
 =pip=. If you only have Python 3 installed, you don't have to care ;-)
 
-On Microsoft Windows (only), you are going to need ~pip install
-pypiwin32~ as prerequisite. For easy Windows File Explorer
+On Microsoft Windows (only), ~pypiwin32~ is an additional as prerequisite. For easy Windows File Explorer
 integration, take a look at [[https://github.com/novoid/integratethis][integratethis]].
 
 Now install filetags via [[https://pip.pypa.io/en/stable/][pip]]: ~pip install filetags~
+
+If you wish to install ~filetags~ from the default branch of the blessed GitHub
+repository, run ~pip install git+https://github.com/novoid/filetags~.
 
 You get updates by executing the very same pip command again.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "filetags"
 description = "Management of simple tags within file names"
-readme = "README.org"
+# readme = "README.org"
 version = "2025.09.02.1"
 keywords = ["tagging", "tags", "file managing", "file management", "files", "tagtrees", "tagstore", "tag-based navigation", "tag-based filter"]
 classifiers=[
@@ -14,11 +14,12 @@ classifiers=[
     ]
 authors = [{name="Karl Voit", email="tools@Karl-Voit.at"}]
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.13"
+requires-python = ">=3.10"  # see https://devguide.python.org/versions/
 dependencies = [
     "clint>=0.5.1",
     "colorama>=0.4.6",
     "pyreadline3>=3.5.4",
+    "pypiwin32; sys_platform == 'win32'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,23 @@ description = "Management of simple tags within file names"
 # readme = "README.org"
 version = "2025.09.02.1"
 keywords = ["tagging", "tags", "file managing", "file management", "files", "tagtrees", "tagstore", "tag-based navigation", "tag-based filter"]
+
+# sequence along https://pypi.org/classifiers
 classifiers=[
-    "Programming Language :: Python :: 3 :: Only",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: GNU General Public License (GPL)",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     ]
+
 authors = [{name="Karl Voit", email="tools@Karl-Voit.at"}]
 license = {file = "LICENSE.txt"}
 requires-python = ">=3.10"  # see https://devguide.python.org/versions/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pyreadline3
-colorama
-clint


### PR DESCRIPTION
The installation now accepts Python 3.10 (and more recent) as interpreter.