### PR TITLE
Handle EOF (ctrl-d) gracefully

### DIFF
--- a/filetags/__init__.py
+++ b/filetags/__init__.py
@@ -2277,7 +2277,12 @@ def ask_for_tags_text_version(vocabulary, upto9_tags_for_shortcuts, hint_str, ta
         print_tag_shortcut_with_numbers(hint_str, tag_list)
 
     logging.debug("interactive mode: asking for tags ...")
-    entered_tags = input(colorama.Style.DIM + 'Tags: ' + colorama.Style.RESET_ALL).strip()
+    try:
+        entered_tags = input(colorama.Style.DIM + 'Tags: ' + colorama.Style.RESET_ALL).strip()
+    except EOFError:
+        logging.info("Received EOF")
+        sys.exit(0)
+
     return extract_tags_from_argument(entered_tags)
 
 


### PR DESCRIPTION
Instead of the traceback it currently throws.

Before:
<img width="1535" height="659" alt="image" src="https://github.com/user-attachments/assets/869c3967-0405-4575-8d72-bf84337527d6" />


After:
<img width="1524" height="333" alt="image" src="https://github.com/user-attachments/assets/bd200752-1217-4eb7-9c1b-f7786f62c3c9" />
