### PR TITLE
Fix pyproject project.license deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -55,7 +54,7 @@ Issues = "https://github.com/novoid/filetags/issues"
 filetags="filetags:main"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
- update [project.license](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)
- remove [pypi classifier](https://pypi.org/classifiers/)
- bump setuptools in accordance

Deprecations:
```
/usr/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated   
!!                                                                                                                                                              
                                                                                                                                                                
        ********************************************************************************                                                                        
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setu
ptools>=77.0.0).                                                                                                                                                
                                                                                                                                                                
        By 2027-Feb-18, you need to update your project and remove deprecated calls                                                                             
        or your builds will no longer be supported.                                                                                                             
                                                                                                                                                                
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.                                                          
        ********************************************************************************                                                                        
                                                                                                                                                                
!! 

/usr/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.               
!!                                                                                                                                                              
                                                                                                                                                                
        ********************************************************************************                                                                        
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v3 (GPLv3)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```