### PR TITLE
ci(ci_pytest.yml): allow a default branch `master`

### DIFF
--- a/.github/workflows/ci_pytest.yml
+++ b/.github/workflows/ci_pytest.yml
@@ -9,10 +9,11 @@ on:
   push:
     branches:
       - main
+      - master
       - dev
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
For greater flexibility, the ci allows `master` as an additional name of the local default branch beside frequently seen `main`. It however replaces `main` by `master` as the default in the blessed repository.